### PR TITLE
Adjust dart extension version

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,4 +2,4 @@ image:
   file: .gitpod.Dockerfile
 vscode:
   extensions:
-    - Dart-Code.dart-code@3.15.0:Bpz5iOHvDeCJ/xmJUC59yQ==
+    - Dart-Code.dart-code@3.6.0:OIKJQXmfWHoIMVCiWrcLsQ==

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,5 @@
 image:
   file: .gitpod.Dockerfile
-
 vscode:
   extensions:
-    - Dart-Code.dart-code@3.13.2:VctB/eBxSv/owCFRO3X0fA==
+    - Dart-Code.dart-code@3.15.0:Bpz5iOHvDeCJ/xmJUC59yQ==


### PR DESCRIPTION
何故か 3.6.0 じゃないとエラーになる。最新版を入れようとするとエラーが表示されるので断念。